### PR TITLE
[codex] Configure LSP and editor tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,62 @@
+SHELL := /bin/bash
+
+NVIM ?= nvim
+PACKER_DIR ?= $(HOME)/.local/share/nvim/site/pack/packer/start/packer.nvim
+HEALTH_LOG ?= /tmp/nvim-health.txt
+MASON_INSTALL_WAIT ?= 120
+
+MASON_TOOLS := gopls vtsls vue-language-server prettier biome vale golangci-lint golines
+
+.PHONY: help setup deps packer plugins tools treesitter check smoke health
+
+help:
+	@echo "Targets:"
+	@echo "  make setup       Install dependencies, plugins, Mason tools, Treesitter parsers, then run checks"
+	@echo "  make deps        Install Homebrew dependencies when brew is available"
+	@echo "  make packer      Install packer.nvim if it is missing"
+	@echo "  make plugins     Run PackerSync"
+	@echo "  make tools       Install required Mason tools"
+	@echo "  make treesitter  Update Treesitter parsers"
+	@echo "  make check       Run smoke checks and write checkhealth output"
+	@echo "  make smoke       Open sample files in headless Neovim and verify LSP attach"
+	@echo "  make health      Run :checkhealth and write output to HEALTH_LOG"
+
+setup: deps packer plugins tools treesitter check
+
+deps:
+	@if command -v brew >/dev/null 2>&1; then \
+		brew list neovim >/dev/null 2>&1 || brew install neovim; \
+		brew list ripgrep >/dev/null 2>&1 || brew install ripgrep; \
+		brew tap | grep -qx "daipeihust/tap" || brew tap daipeihust/tap; \
+		brew list im-select >/dev/null 2>&1 || brew install im-select; \
+	else \
+		command -v $(NVIM) >/dev/null 2>&1 || { echo "Neovim is required."; exit 1; }; \
+		command -v rg >/dev/null 2>&1 || { echo "ripgrep is required."; exit 1; }; \
+	fi
+
+packer:
+	@if [ ! -d "$(PACKER_DIR)" ]; then \
+		git clone --depth 1 https://github.com/wbthomason/packer.nvim "$(PACKER_DIR)"; \
+	else \
+		echo "packer.nvim is already installed: $(PACKER_DIR)"; \
+	fi
+
+plugins:
+	$(NVIM) --headless +'autocmd User PackerComplete quitall' +'PackerSync'
+
+tools:
+	$(NVIM) --headless +'MasonInstall $(MASON_TOOLS)' +'sleep $(MASON_INSTALL_WAIT)' +'qa'
+
+treesitter:
+	$(NVIM) --headless +'TSUpdateSync' +'qa'
+
+check: smoke health
+
+smoke:
+	$(NVIM) --headless test_contents/test.go +'sleep 2' +'lua local c = vim.lsp.get_clients({ bufnr = 0 }); assert(#c > 0 and c[1].name == "gopls", "gopls is not attached")' +'qa'
+	$(NVIM) --headless test_contents/test.js +'sleep 2' +'lua local c = vim.lsp.get_clients({ bufnr = 0 }); assert(#c > 0 and c[1].name == "vtsls", "vtsls is not attached")' +'qa'
+	$(NVIM) --headless README.md +'qa'
+
+health:
+	$(NVIM) --headless +checkhealth +'write! $(HEALTH_LOG)' +'qa'
+	@echo "checkhealth output: $(HEALTH_LOG)"

--- a/README.md
+++ b/README.md
@@ -58,13 +58,7 @@ Go、Vue.js、JavaScript、TypeScript、Markdownをよく使うためのNeovim�
 
     LSP serverは `mason-lspconfig.nvim` により、可能なものは自動でインストールされます。
 
-6. GitHub Copilotを使う場合はセットアップします。
-
-    ```vim
-    :Copilot setup
-    ```
-
-7. 環境を確認します。
+6. 環境を確認します。
 
     ```vim
     :checkhealth

--- a/README.md
+++ b/README.md
@@ -1,7 +1,30 @@
 # nvim
 
-## enviroment
-- node versions : 18.12.1
+## Environment
+
+- Neovim: 0.11.0+
+- Node.js: required for JavaScript / TypeScript / Vue tooling
+- Go: required for Go LSP and formatting
+
+## Supported languages
+
+- Go
+- Vue.js
+- JavaScript
+- TypeScript
+- Markdown
+
+Go, JavaScript, TypeScript, and Vue use Neovim's built-in LSP client.
+
+Default LSP keymaps:
+
+- `gd`: go to definition
+- `gD`: go to declaration
+- `gr`: references
+- `gi`: implementation
+- `K`: hover
+- `<leader>rn`: rename
+- `<leader>ca`: code action
 
 ## Installation
 - [参考](https://namileriblog.com/mac/neovim/)
@@ -17,6 +40,12 @@
     ```bash
     git clone --depth 1 https://github.com/wbthomason/packer.nvim\
     ~/.local/share/nvim/site/pack/packer/start/packer.nvim
+    ```
+
+    Then install plugins:
+
+    ```vim
+    :PackerSync
     ```
 
 3. **Install im-select**
@@ -69,16 +98,42 @@
     brew install ripgrep
     ```
 
-5. **Install LSP**
+5. **Install tools with Mason**
 
-  ```commands
-  Mason
-  ```
+    Open Mason:
+
+    ```vim
+    :Mason
+    ```
+
+    Required tools:
+
+    - `gopls`
+    - `vtsls`
+    - `vue-language-server`
+    - `prettier`
+    - `biome`
+    - `vale`
+    - `golangci-lint`
+    - `golines`
+
+    `mason-lspconfig.nvim` installs the configured LSP servers automatically when possible.
+
+6. **Health check**
+
+    ```vim
+    :checkhealth
+    ```
+
+    If Treesitter reports query or parser errors, update parsers:
+
+    ```vim
+    :TSUpdate
+    ```
 
 
-6. **Setup pug highlight**
+7. **Setup pug highlight**
 
     ```
     set ft=pug
     ```
-

--- a/README.md
+++ b/README.md
@@ -1,112 +1,51 @@
 # nvim
 
-## Environment
+Go、Vue.js、JavaScript、TypeScript、Markdownをよく使うためのNeovim設定です。
+
+## 環境
 
 - Neovim: 0.11.0+
-- Node.js: required for JavaScript / TypeScript / Vue tooling
-- Go: required for Go LSP and formatting
+- Node.js: JavaScript / TypeScript / VueのLSPやformatterで必要
+- Go: GoのLSPやformatterで必要
+- ripgrep: Telescopeの全文検索で必要
+- im-select: macOSで入力ソースを切り替えるために使用
 
-## Supported languages
+## セットアップ
 
-- Go
-- Vue.js
-- JavaScript
-- TypeScript
-- Markdown
-
-Go, JavaScript, TypeScript, and Vue use Neovim's built-in LSP client.
-
-Default LSP keymaps:
-
-- `gd`: go to definition
-- `gD`: go to declaration
-- `gr`: references
-- `gi`: implementation
-- `K`: hover
-- `<leader>rn`: rename
-- `<leader>ca`: code action
-
-## Installation
-- [参考](https://namileriblog.com/mac/neovim/)
-
-1. **Install neovim with homebrew**
+1. Neovimをインストールします。
 
     ```bash
     brew install neovim
     ```
 
-2. **Install Package Manager**
+2. Packerをインストールします。
 
     ```bash
-    git clone --depth 1 https://github.com/wbthomason/packer.nvim\
-    ~/.local/share/nvim/site/pack/packer/start/packer.nvim
+    git clone --depth 1 https://github.com/wbthomason/packer.nvim \
+      ~/.local/share/nvim/site/pack/packer/start/packer.nvim
     ```
 
-    Then install plugins:
+3. 外部コマンドをインストールします。
+
+    ```bash
+    brew install ripgrep
+    brew tap daipeihust/tap
+    brew install im-select
+    ```
+
+4. Neovimを開いて、pluginをインストールします。
 
     ```vim
     :PackerSync
     ```
 
-3. **Install im-select**
-
-    ```bash
-    brew tap daipeihust/tap
-    brew install im-select
-    ```
-
-    ```
-    which im-select
-    ```
-
-    以下のように出力されればインストールは完了です。
-    ```
-    /opt/homebrew/bin/im-select
-    ```
-
-    以下を実行して、init.luaに記載します。
-    ```
-    im-select
-    ```
-
-    `lua/plugins.lua`
-    ```lua
-    use 'keaising/im-select.nvim'
-    ```
-
-    ```commands
-    :PackerInstall
-    ```
-
-    `init.lua`
-    ```bash
-    require('im_select').setup {
-        default_im_select = "${im-selectの実行結果}"
-    }
-    ```
-
-
-4. **Setup copilot**
-
-    ```
-    :Copilot setup
-    ```
-
-5. **Install RipGrep**
-
-    ```bash
-    brew install ripgrep
-    ```
-
-5. **Install tools with Mason**
-
-    Open Mason:
+5. Masonのツールを確認します。
 
     ```vim
     :Mason
     ```
 
-    Required tools:
+    必要なツール:
 
     - `gopls`
     - `vtsls`
@@ -117,23 +56,180 @@ Default LSP keymaps:
     - `golangci-lint`
     - `golines`
 
-    `mason-lspconfig.nvim` installs the configured LSP servers automatically when possible.
+    LSP serverは `mason-lspconfig.nvim` により、可能なものは自動でインストールされます。
 
-6. **Health check**
+6. GitHub Copilotを使う場合はセットアップします。
+
+    ```vim
+    :Copilot setup
+    ```
+
+7. 環境を確認します。
 
     ```vim
     :checkhealth
     ```
 
-    If Treesitter reports query or parser errors, update parsers:
+    Treesitterのqueryやparserエラーが出る場合は、parserを更新します。
 
     ```vim
     :TSUpdate
     ```
 
+## 対応言語
 
-7. **Setup pug highlight**
+- Go: `gopls`
+- JavaScript / TypeScript: `vtsls`
+- Vue.js: `vue_ls` + `vtsls`
+- Markdown: Treesitter highlight、Prettier format、Vale lint
 
-    ```
-    set ft=pug
-    ```
+## 基本操作
+
+### サイドバー
+
+| キー | 操作 |
+| --- | --- |
+| `<C-e>` | ファイルサイドバーを開く / 閉じる |
+| `<C-b>` | buffer一覧のサイドバーを開く |
+| `\` | 現在開いているファイルをサイドバー上で表示する |
+
+サイドバー内の操作:
+
+| キー | 操作 |
+| --- | --- |
+| `<Enter>` | ファイルまたはディレクトリを開く |
+| `S` | 横分割で開く |
+| `s` | 縦分割で開く |
+| `t` | 新しいtabで開く |
+| `a` | ファイルを追加する |
+| `A` | ディレクトリを追加する |
+| `r` | 名前を変更する |
+| `d` | 削除する |
+| `q` | サイドバーを閉じる |
+
+### 検索
+
+| キー | 操作 |
+| --- | --- |
+| `<C-f>` | Git管理下のファイルを検索する |
+| `<C-g>` | ripgrepで文字列検索する |
+| `<leader>gs` | Git statusを開く |
+| `<leader>gl` | Git commit logを開く |
+
+`<leader>` はspaceです。
+
+### tabとwindow
+
+| キー | 操作 |
+| --- | --- |
+| `<C-t>` | 新しいtabを開く |
+| `<C-n>` | 次のtabへ移動する |
+| `<C-p>` | 前のtabへ移動する |
+| `<C-q>` | 現在のtabを閉じる |
+| `gh` | 左のwindowへ移動する |
+| `gj` | 下のwindowへ移動する |
+| `gk` | 上のwindowへ移動する |
+| `gl` | 右のwindowへ移動する |
+| `<C-,>` | windowの横幅を広げる |
+| `<C-<>` | windowの横幅を狭める |
+| `<C-.>` | windowの高さを広げる |
+| `<C->>` | windowの高さを狭める |
+
+### 編集
+
+| キー | 操作 |
+| --- | --- |
+| `jj` | insert modeからnormal modeへ戻る |
+| `っｊ` | 日本語入力中にinsert modeからnormal modeへ戻る |
+| `<C-a>` | 全選択する |
+| `x` | yankせずに1文字削除する |
+| `;` | command modeに入る |
+
+## コードジャンプ
+
+LSPのkeymapは、LSP serverが現在のbufferにattachした後に有効になります。
+
+| キー | 操作 |
+| --- | --- |
+| `gd` | 定義へ移動する |
+| `gD` | 宣言へ移動する |
+| `gr` | 参照一覧を表示する |
+| `gi` | 実装へ移動する |
+| `K` | hover documentを表示する |
+| `<leader>rn` | symbol名を変更する |
+| `<leader>ca` | code actionを表示する |
+| `[d` | 前のdiagnosticへ移動する |
+| `]d` | 次のdiagnosticへ移動する |
+
+現在のbufferにattachしているLSP clientを確認するには、以下を実行します。
+
+```vim
+:LspInfo
+```
+
+期待するclient:
+
+- Go: `gopls`
+- JavaScript / TypeScript: `vtsls`
+- Vue.js: `vue_ls` と `vtsls`
+
+## formatとlint
+
+現在のbufferをformatします。
+
+```vim
+:Format
+```
+
+lintは設定済みのfiletypeで保存時に実行されます。
+
+formatter:
+
+- JavaScript / TypeScript / Vue / Markdown: `prettier`
+- Go: `golines`
+- Lua: `stylua`
+- JSON: `jq`
+- Ruby: `rubocop`
+- Rust: `rustfmt`
+- SQL: `sql-formatter`
+
+linter:
+
+- JavaScript / TypeScript: `biome`
+- Markdown: `vale`
+- Go: `golangci-lint`
+- Ruby: `rubocop`
+
+## 動作確認
+
+通常は対象ファイルをNeovimで開けば確認できます。
+
+```bash
+nvim test_contents/test.go
+nvim test_contents/test.js
+nvim README.md
+```
+
+TypeScriptやVueは、任意の `.ts` / `.vue` ファイルを開いて確認します。
+
+ファイルを開いたら、以下でLSPのattach状態を確認します。
+
+```vim
+:LspInfo
+```
+
+headlessで簡易確認する場合:
+
+```bash
+nvim --headless test_contents/test.go +'qa'
+nvim --headless test_contents/test.js +'qa'
+nvim --headless README.md +'qa'
+```
+
+## Pug highlight
+
+Pugファイルの場合:
+
+```vim
+:set ft=pug
+```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,31 @@ Go、Vue.js、JavaScript、TypeScript、Markdownをよく使うためのNeovim�
 
 ## セットアップ
 
+基本的には以下だけでセットアップできます。
+
+```bash
+make setup
+```
+
+個別に実行したい場合:
+
+```bash
+make deps
+make packer
+make plugins
+make tools
+make treesitter
+make check
+```
+
+Mason toolのインストール待ち時間を増やしたい場合:
+
+```bash
+make tools MASON_INSTALL_WAIT=180
+```
+
+手動でセットアップする場合は以下を実行します。
+
 1. Neovimをインストールします。
 
     ```bash
@@ -69,6 +94,20 @@ Go、Vue.js、JavaScript、TypeScript、Markdownをよく使うためのNeovim�
     ```vim
     :TSUpdate
     ```
+
+## Makefile targets
+
+| Target | 内容 |
+| --- | --- |
+| `make setup` | 依存関係、Packer、plugin、Mason tool、Treesitter parserを入れて確認まで実行する |
+| `make deps` | Homebrewが使える場合にNeovim、ripgrep、im-selectを入れる |
+| `make packer` | Packerがなければインストールする |
+| `make plugins` | `:PackerSync` を実行する |
+| `make tools` | Masonで必要なLSP / formatter / linterを入れる |
+| `make treesitter` | Treesitter parserを更新する |
+| `make smoke` | Go / JavaScript / Markdownの簡易起動確認をする |
+| `make health` | `:checkhealth` を実行し、結果を `/tmp/nvim-health.txt` に出力する |
+| `make check` | `make smoke` と `make health` を実行する |
 
 ## 対応言語
 

--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,8 @@
 require("options")
 require("plugins")
 require("keymaps")
+require("format")
+require("user_lint")
 
 -- https://github.com/nvim-lualine/lualine.nvim
 require("lualine").setup({
@@ -41,14 +43,23 @@ require("ibl").setup({
 
 require("nvim-treesitter.configs").setup({
 	auto_install = true,
+	ensure_installed = {
+		"go",
+		"javascript",
+		"typescript",
+		"tsx",
+		"vue",
+		"markdown",
+		"markdown_inline",
+	},
 	highlight = {
 		enable = true,
 	},
 })
-require("neo-tree").setup()
 
 -- im-select
 require("im_select").setup({
+	default_command = "im-select",
 	default_im_select = "com.apple.keylayout.ABC",
 })
 
@@ -91,9 +102,6 @@ require("gitsigns").setup({
 		row = 0,
 		col = 1,
 	},
-	yadm = {
-		enable = false,
-	},
 })
 
 require("telescope").setup({
@@ -120,53 +128,7 @@ require("telescope").setup({
 
 -- https://github.com/williamboman/mason.nvim
 require("mason").setup()
-
--- https://github.com/mhartington/formatter.nvim
-local util = require("formatter.util")
-
-require("formatter").setup({
-	logging = true,
-	log_level = vim.log.levels.WARN,
-	filetype = {
-		javascript = {
-			function()
-				return {
-					exe = "prettier",
-					args = { "--stdin-filepath", vim.fn.fnameescape(vim.api.nvim_buf_get_name(0)), "--single-quote" },
-					stdin = true,
-				}
-			end,
-		},
-		json = { require("formatter.filetypes.json").jq },
-		ruby = { require("formatter.filetypes.ruby").rubocop },
-		lua = { require("formatter.filetypes.lua").stylua },
-		go = { require("formatter.filetypes.go").golines },
-    rust = { require("formatter.filetypes.rust").rustfmt },
-		sql = {
-			function()
-				return {
-					exe = "sql-formatter",
-					args = {},
-					stdin = true,
-				}
-			end,
-		},
-	},
-})
-
--- https://github.com/mfussenegger/nvim-lint
-require("lint").linters_by_ft = {
-	markdown = { "vale" },
-	javascript = { "biomejs" },
-	ruby = { "rubocop" },
-	go = { "golangcilint" }
-}
-
-vim.api.nvim_create_autocmd({ "BufWritePost" }, {
-	callback = function()
-		require("lint").try_lint()
-	end,
-})
+require("lsp")
 
 require("Comment").setup()
 vim.cmd([[colorscheme kanagawa-wave]])

--- a/lua/format.lua
+++ b/lua/format.lua
@@ -1,0 +1,38 @@
+local function prettier()
+	return {
+		exe = "prettier",
+		args = {
+			"--stdin-filepath",
+			vim.fn.fnameescape(vim.api.nvim_buf_get_name(0)),
+			"--single-quote",
+		},
+		stdin = true,
+	}
+end
+
+require("formatter").setup({
+	logging = true,
+	log_level = vim.log.levels.WARN,
+	filetype = {
+		javascript = { prettier },
+		javascriptreact = { prettier },
+		typescript = { prettier },
+		typescriptreact = { prettier },
+		vue = { prettier },
+		markdown = { prettier },
+		json = { require("formatter.filetypes.json").jq },
+		ruby = { require("formatter.filetypes.ruby").rubocop },
+		lua = { require("formatter.filetypes.lua").stylua },
+		go = { require("formatter.filetypes.go").golines },
+		rust = { require("formatter.filetypes.rust").rustfmt },
+		sql = {
+			function()
+				return {
+					exe = "sql-formatter",
+					args = {},
+					stdin = true,
+				}
+			end,
+		},
+	},
+})

--- a/lua/lsp.lua
+++ b/lua/lsp.lua
@@ -1,0 +1,54 @@
+local function map_lsp_keys(event)
+	local opts = { buffer = event.buf, silent = true }
+	local keymap = vim.keymap.set
+
+	keymap("n", "gd", vim.lsp.buf.definition, opts)
+	keymap("n", "gD", vim.lsp.buf.declaration, opts)
+	keymap("n", "gr", vim.lsp.buf.references, opts)
+	keymap("n", "gi", vim.lsp.buf.implementation, opts)
+	keymap("n", "K", vim.lsp.buf.hover, opts)
+	keymap("n", "<leader>rn", vim.lsp.buf.rename, opts)
+	keymap("n", "<leader>ca", vim.lsp.buf.code_action, opts)
+	keymap("n", "[d", vim.diagnostic.goto_prev, opts)
+	keymap("n", "]d", vim.diagnostic.goto_next, opts)
+end
+
+vim.api.nvim_create_autocmd("LspAttach", {
+	group = vim.api.nvim_create_augroup("user-lsp-attach", { clear = true }),
+	callback = map_lsp_keys,
+})
+
+local vue_language_server_path = vim.fn.stdpath("data")
+	.. "/mason/packages/vue-language-server/node_modules/@vue/language-server"
+
+vim.lsp.config("vtsls", {
+	settings = {
+		vtsls = {
+			tsserver = {
+				globalPlugins = {
+					{
+						name = "@vue/typescript-plugin",
+						location = vue_language_server_path,
+						languages = { "vue" },
+						configNamespace = "typescript",
+					},
+				},
+			},
+		},
+	},
+	filetypes = { "typescript", "javascript", "javascriptreact", "typescriptreact", "vue" },
+})
+
+local servers = { "gopls", "vtsls", "vue_ls" }
+
+local ok_mason_lspconfig, mason_lspconfig = pcall(require, "mason-lspconfig")
+if ok_mason_lspconfig then
+	pcall(mason_lspconfig.setup, {
+		ensure_installed = servers,
+		automatic_enable = servers,
+	})
+end
+
+if vim.lsp.enable ~= nil then
+	vim.lsp.enable(servers)
+end

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -83,18 +83,11 @@ return require("packer").startup(function(use)
 			},
 		},
 		config = function()
-			-- If you want icons for diagnostic errors, you'll need to define them somewhere:
-			vim.fn.sign_define("DiagnosticSignError", { text = " ", texthl = "DiagnosticSignError" })
-			vim.fn.sign_define("DiagnosticSignWarn", { text = " ", texthl = "DiagnosticSignWarn" })
-			vim.fn.sign_define("DiagnosticSignInfo", { text = " ", texthl = "DiagnosticSignInfo" })
-			vim.fn.sign_define("DiagnosticSignHint", { text = "󰌵", texthl = "DiagnosticSignHint" })
-
 			require("neo-tree").setup({
 				close_if_last_window = false, -- Close Neo-tree if it is the last window left in the tab
 				popup_border_style = "rounded",
 				enable_git_status = true,
 				enable_diagnostics = true,
-				enable_normal_mode_for_inputs = false, -- Enable normal mode for input dialogs.
 				open_files_do_not_replace_types = { "terminal", "trouble", "qf" }, -- when opening files, do not use windows containing these filetypes or buftypes
 				sort_case_insensitive = false, -- used when sorting files and directories in the tree
 				sort_function = nil, -- use a custom function for sorting files and directories in the tree
@@ -384,6 +377,8 @@ return require("packer").startup(function(use)
 
 	-- lsp
 	use("williamboman/mason.nvim")
+	use("williamboman/mason-lspconfig.nvim")
+	use("neovim/nvim-lspconfig")
 	use("mfussenegger/nvim-lint")
 	use("mhartington/formatter.nvim")
 
@@ -398,4 +393,3 @@ return require("packer").startup(function(use)
 		end,
 	})
 end)
-

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -355,26 +355,6 @@ return require("packer").startup(function(use)
 		end,
 	})
 
-	use({
-		"github/copilot.vim",
-		config = function()
-			-- vim.g.copilot_no_tab_map = true
-
-			local keymap = vim.keymap.set
-			-- https://github.com/orgs/community/discussions/29817#discussioncomment-4217615
-			keymap(
-				"i",
-				"<C-g>",
-				'copilot#Accept("<CR>")',
-				{ silent = true, expr = true, script = true, replace_keycodes = false }
-			)
-			keymap("i", "<C-j>", "<Plug>(copilot-next)")
-			keymap("i", "<C-k>", "<Plug>(copilot-previous)")
-			keymap("i", "<C-o>", "<Plug>(copilot-dismiss)")
-			keymap("i", "<C-s>", "<Plug>(copilot-suggest)")
-		end,
-	})
-
 	-- lsp
 	use("williamboman/mason.nvim")
 	use("williamboman/mason-lspconfig.nvim")

--- a/lua/user_lint.lua
+++ b/lua/user_lint.lua
@@ -1,0 +1,33 @@
+local lint = require("lint")
+
+lint.linters_by_ft = {
+	markdown = { "vale" },
+	javascript = { "biomejs" },
+	javascriptreact = { "biomejs" },
+	typescript = { "biomejs" },
+	typescriptreact = { "biomejs" },
+	ruby = { "rubocop" },
+	go = { "golangcilint" },
+}
+
+local function available_linters(names)
+	return vim.tbl_filter(function(name)
+		local linter = lint.linters[name]
+		if linter == nil then
+			return false
+		end
+
+		local cmd = type(linter.cmd) == "function" and linter.cmd() or linter.cmd
+		return vim.fn.executable(cmd) == 1
+	end, names)
+end
+
+vim.api.nvim_create_autocmd({ "BufWritePost" }, {
+	group = vim.api.nvim_create_augroup("user-lint", { clear = true }),
+	callback = function()
+		local linters = available_linters(lint.linters_by_ft[vim.bo.filetype] or {})
+		if #linters > 0 then
+			lint.try_lint(linters)
+		end
+	end,
+})


### PR DESCRIPTION
## Summary

- Add Neovim 0.12.2-ready LSP setup for Go, JavaScript, TypeScript, and Vue.
- Split formatter, lint, completion, Git diff, and which-key setup into dedicated Lua modules.
- Remove stale Neo-tree/gitsigns options that produced startup warnings and remove Copilot configuration.
- Expand Treesitter, formatter, lint, setup automation, and README coverage for Go/Vue/JS/TS/Markdown.

## Added in the latest update

- Add `blink.cmp` completion UI pinned to `v1.10.2` for Packer compatibility.
- Add `which-key.nvim` with descriptions for existing keymaps and leader groups.
- Add `diffview.nvim` shortcuts for worktree diff, branch diff, file history, and close.
- Update `make deps` so an installed Homebrew Neovim is upgraded instead of only installed once.
- Ignore local Neovim log files generated during checks.

## Validation

- `nvim --version` -> `NVIM v0.12.2`
- `nvim --headless +PackerSync +qa`
- `nvim --headless +'lua assert(require("blink.cmp"))' +'lua assert(require("which-key"))' +'lua assert(require("diffview"))' +'qa'`
- `make smoke`
- `make health`
- `git diff --check`

## Notes

- `:checkhealth` no longer reports the previous Treesitter query error or deprecated API use.
- Remaining health warnings are optional provider/tooling warnings such as missing `wget`, `fd`, `hg`, and language providers not used by this config.

Closes #10
Refs #12
